### PR TITLE
Fix file saving and expose uploads

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -63,14 +63,16 @@ async def create_case(
     cid = len(cases_db) + 1
     media_paths = []
     for f in media_files:
-        path = os.path.join(UPLOAD_DIR, f'{cid}_{f.filename}')
+        filename = os.path.basename(f.filename)
+        path = os.path.join(UPLOAD_DIR, f"{cid}_{filename}")
         with open(path, 'wb') as out:
             out.write(await f.read())
         media_paths.append(path)
 
     invoice_path = None
     if invoice_file:
-        invoice_path = os.path.join(UPLOAD_DIR, f'{cid}_inv_{invoice_file.filename}')
+        inv_filename = os.path.basename(invoice_file.filename)
+        invoice_path = os.path.join(UPLOAD_DIR, f"{cid}_inv_{inv_filename}")
         with open(invoice_path, 'wb') as out:
             out.write(await invoice_file.read())
 
@@ -105,6 +107,8 @@ async def get_cases():
 FRONTEND_DIST = os.path.join(os.path.dirname(__file__), '..', 'frontend', 'dist')
 if os.path.isdir(FRONTEND_DIST):
     app.mount('/', StaticFiles(directory=FRONTEND_DIST, html=True), name='frontend')
+
+app.mount('/uploads', StaticFiles(directory=UPLOAD_DIR), name='uploads')
 
 if __name__ == '__main__':
     import uvicorn


### PR DESCRIPTION
## Summary
- expose uploads directory via FastAPI
- sanitize uploaded filenames when saving

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68706cd60a408320ae5acd964cb70616