### PR TITLE
Fix NewCase fetch URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 npm run start
 ```
 
-The frontend expects the backend on `http://localhost:8000`.
+The frontend communicates with the backend using relative paths, so it works as long as both are served from the same origin (for example when running locally on `http://localhost:8000` or when deployed together on Railway).
 
 ## Deploying with Nixpacks
 

--- a/frontend/src/pages/NewCase.jsx
+++ b/frontend/src/pages/NewCase.jsx
@@ -29,7 +29,7 @@ export default function NewCase() {
     Object.entries(form).forEach(([k, v]) => data.append(k, v));
     mediaFiles.forEach(f => data.append('media_files', f));
     if (invoiceFile) data.append('invoice_file', invoiceFile);
-    await fetch('http://localhost:8000/cases', {
+    await fetch('/cases', {
       method: 'POST',
       body: data
     });


### PR DESCRIPTION
## Summary
- update NewCase form to send POST to `/cases`
- clarify README about backend URL

## Testing
- `npm --prefix frontend run test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68706cdea4848320af860ac87f42977b