### PR TITLE
Update README for backend URL info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 npm run start
 ```
 
-The frontend expects the backend on `http://localhost:8000`.
+When running locally, the frontend expects the backend on `http://localhost:8000`. In production the frontend calls the API using relative URLs, so no host is specified.
 
 ## Deploying with Nixpacks
 


### PR DESCRIPTION
## Summary
- clarify that the backend runs on port 8000 locally
- note that production builds use relative URLs instead of a host

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68706ce143f08320bf9e051c49f14b8a